### PR TITLE
WIP: grep on InputStreams

### DIFF
--- a/unix4j-core/unix4j-base/src/main/java/org/unix4j/io/FileInput.java
+++ b/unix4j-core/unix4j-base/src/main/java/org/unix4j/io/FileInput.java
@@ -34,6 +34,11 @@ public class FileInput extends ReaderInput {
 		this.fileInfo = fileStream.toString();
 	}
 
+	public FileInput(InputStream inputStream) {
+	    super(new InputStreamReader(inputStream), false);
+	    this.fileInfo = inputStream.toString();
+	}
+
 	public FileInput(FileDescriptor fileDesc) {
 		super(new FileReader(fileDesc), true);
 		this.fileInfo = fileDesc.toString();
@@ -66,6 +71,10 @@ public class FileInput extends ReaderInput {
 	 */
 	public static List<FileInput> multiple(List<File> files) {
 		return multiple(files.stream());
+	}
+
+	public static List<FileInput> multiple(InputStream... streams) {
+	    return Stream.of(streams).map(FileInput::new).collect(Collectors.toList());
 	}
 
 	private static List<FileInput> multiple(Stream<File> files) {

--- a/unix4j-core/unix4j-command/src/main/java/org/unix4j/unix/grep/GrepCommand.java
+++ b/unix4j-core/unix4j-command/src/main/java/org/unix4j/unix/grep/GrepCommand.java
@@ -32,6 +32,9 @@ class GrepCommand extends AbstractCommand<GrepArguments> {
 			final List<File> files = FileUtil.expandFiles(context.getCurrentDirectory(), args.getPaths());
 			final List<FileInput> inputs = FileInput.multiple(files);
 			return getFileInputProcessor(inputs, context, output, args);
+		} else if (args.isStreamsSet()) {
+		    final List<FileInput> inputs = FileInput.multiple(args.getStreams());
+		    return getFileInputProcessor(inputs, context, output, args);
 		}
 
 		//from standard input

--- a/unix4j-core/unix4j-command/src/main/resources/command-definition/grep.xml
+++ b/unix4j-core/unix4j-command/src/main/resources/command-definition/grep.xml
@@ -31,6 +31,9 @@
 			the given {@code regexp} string using case-sensitive comparison. 
 			Line endings are not relevant for the comparison.
 		</method>
+		<method args="regexp,streams" usesStandardInput="false">
+			TBD
+		</method>
 		<method args="pattern" usesStandardInput="true">
 			Filters the input lines from the standard input and writes the
 			matching lines to the standard output. Every line is matched against
@@ -147,6 +150,9 @@
 			The input files to be searched for the pattern; relative paths are 
 			not resolved (use the string paths argument to enable relative path 
 			resolving based on the current working directory).
+		</operand>
+		<operand name="streams" type="java.io.InputStream...">
+			TBD
 		</operand>
 		<operand name="args" type="String...">
 			String arguments defining the options and operands for the command. 


### PR DESCRIPTION
The background for this PR is that file-search functionality was recently added to [muCommander](https://github.com/mucommander/mucommander) but we currently only search files by their name, there's no way to search by the content of the files ([that appears to be desired](https://aremareff.blogspot.com/2020/07/a-great-and-lacking-java-based-file.html)). It seems like the `grep` implementation in `unix4j` can be used for this.

However, in muCommander we abstract files with the [AbstractFile class](https://github.com/mucommander/mucommander/blob/master/mucommander-commons-file/src/main/java/com/mucommander/commons/file/AbstractFile.java). We have concrete implementations of the AbstractFile for various formats, like SFTP, SMB and so on, that we cannot use Java's File/Path for. The content of AbstractFiles can be read using Java's InputStream.

Looking at `unix4j` it seems it intended to use Java's FileInputStream but (a) Looks like it's not used at the moment (at least not by the `grep` command; (b) in muCommander, the InputStreams are not necessarily FileInputStreams.

This PR makes it possible for the `grep` command to operate on Java's InputStream.